### PR TITLE
Add docs for verible lint and format usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # APB Protocol
 
 Implementation of the AMBA Advanced Peripheral Bus (APB) protocol using SystemVerilog.
+
+## Development
+
+See [CONTRIBUTING.md](docs/CONTRIBUTING.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing
+
+## Verible Code Quality Tools
+
+This project uses the [Verible tool suite](https://github.com/chipsalliance/verible) to ensure code quality is maintained, specifically through linting and formatting to common standards.
+
+### **Verible Installation Script**
+
+The `/scripts/verible_install.sh` script automates the process of downloading, extracting, and setting up the latest version of the tool suite for a single user on a PSU ECE server such as mo.ece.pdx.edu (or similar Linux machine). The binaries are installed in `~/bin`, ensuring they do not interfere with system-wide packages. Alternatively, the desired release can be downloaded directly from the [Verible releases page](https://github.com/chipsalliance/verible/releases).
+
+**Note:** This script will create a `bin` directory in your home directory and add it to your `PATH`.
+
+#### **How to Run It**
+
+Perform the following from the `scripts` directory.
+
+1. **Ensure the install script has execute permissions**
+```bash
+chmod +x install_verible.sh
+```
+
+2. **Run the script**
+```bash
+./install_verible.sh
+```
+
+3. **(Optional) Manually verify the installation**
+```bash
+verible-verilog-lint --version
+```
+
+If the installation was successful, you should see the Verible version printed in the terminal.
+
+### **Basic Verible Usage**
+
+**Verible Verilog Linter** (`verible-verilog-lint`)
+
+This tool checks Verilog/SystemVerilog files for style and syntax issues. See [the docs](https://chipsalliance.github.io/verible/verilog_lint.html) for additional details.
+
+**Basic usage:**
+
+```bash
+verible-verilog-lint file.sv
+```
+- Runs the linter on `file.sv` and reports any warnings or errors.
+
+**Fix Lint Errors Automatically (if possible):**
+
+```bash
+verible-verilog-lint --autofix file.sv
+```
+
+**Suppress Specific Lint Warnings:**
+
+```bash
+verible-verilog-lint --rules=-some-rule file.sv
+```
+- Replace `some-rule` with the rule you want to disable.
+- You can disable multiple rules: `--rules=-rule1,-rule2`
+
+**List Available Linting Rules:**
+
+```bash
+verible-verilog-lint --help_rules
+```
+_____________
+
+**Verible Verilog Formatter** (`verible-verilog-format`)
+
+This tool automatically formats Verilog/SystemVerilog code according to style guidelines. See [the docs](https://chipsalliance.github.io/verible/verilog_format.html) for additional details.
+
+**Modify the File In-Place:**
+
+```bash
+verible-verilog-format --inplace file.sv
+```
+- This overwrites `file.sv` with the formatted version.
+
+
+**Format All `.sv` Files in a Directory:**
+
+```bash
+verible-verilog-format --inplace *.sv
+```
+
+**Control Formatting Style:**
+
+```bash
+verible-verilog-format --indentation_spaces=4 file.sv
+```
+- Adjusts indentation width.
+
+______________
+
+
+## Setting Up a GitHub Deploy Key
+
+A **deploy key** is an SSH key that grants access to a single GitHub repository. We'll be using this as a secure way to grant access to our project directory, while limiting permissions for a key stored on a PSU server.
+
+1. **Generate an SSH Key**
+
+Run the following command, replacing `your_email@example.com` with your email:
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+- When prompted, press **Enter** to accept the default location (`~/.ssh/id_ed25519`).
+- You may also add a passphrase for extra security. This is optional but recommended.
+
+
+2. **Add the Public Key to GitHub**
+
+Copy the contents of your **public key** to the clipboard:
+
+```bash
+cat ~/.ssh/id_ed25519.pub
+```
+
+Go to the project github repository and navigate to **Settings > Deploy keys**. Click to **Add deploy key**. Give it a descriptive title (e.g. "PSU ECE server Mo"). Paste the **public key** into the "Key" field and select **Allow write access**. Last, click to **Add key**.
+
+You should now have access to **push** to the project repository from the server. You may also need to update the git configuration on the server to use the correct name and email address associated with your github account.
+
+_________________
+
+## Basic `vlog` and `vsim` usage
+
+TODO
+

--- a/scripts/verible_install.sh
+++ b/scripts/verible_install.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Get the latest Verible version tag
+VERIBLE_VERSION=$(curl -s https://api.github.com/repos/chipsalliance/verible/releases/latest | grep "tag_name" | cut -d '"' -f 4)
+
+# Define the download URL
+VERIBLE_TARBALL="verible-${VERIBLE_VERSION}-linux-static-x86_64.tar.gz"
+DOWNLOAD_URL="https://github.com/chipsalliance/verible/releases/download/${VERIBLE_VERSION}/${VERIBLE_TARBALL}"
+
+echo "Downloading Verible version: ${VERIBLE_VERSION}"
+wget -q --show-progress "$DOWNLOAD_URL"
+
+# Extract the tarball
+echo "Extracting ${VERIBLE_TARBALL}..."
+tar -xvzf "$VERIBLE_TARBALL"
+
+# Create ~/bin directory if it doesn't exist
+mkdir -p ~/bin
+
+# Move binaries to ~/bin
+mv verible-${VERIBLE_VERSION}/bin/* ~/bin/
+
+# Cleanup: Remove the tar.gz file and extracted folder
+rm -rf "$VERIBLE_TARBALL" "verible-${VERIBLE_VERSION}"
+
+# Ensure ~/bin is in PATH
+if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+    echo 'export PATH=$HOME/bin:$PATH' >> ~/.bashrc
+    echo 'export PATH=$HOME/bin:$PATH' >> ~/.zshrc
+fi
+export PATH=$HOME/bin:$PATH
+
+# Source the appropriate shell configuration if it exists
+if [ -f ~/.bashrc ]; then
+    source ~/.bashrc
+elif [ -f ~/.zshrc ]; then
+    source ~/.zshrc
+fi
+
+# Verify installation
+echo "Verifying Verible installation..."
+if command -v verible-verilog-lint &> /dev/null; then
+    verible-verilog-lint --version
+    echo "Verible successfully installed!"
+else
+    echo "Error: Verible installation failed."
+    exit 1
+fi
+


### PR DESCRIPTION
Adds docs and a verible install script to provide instructions for setting up a development environment on a PSU ECE server or similar system.