### PR TITLE
Add case analyses for read transfers and protection unit support

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,49 @@
+# Testing
+
+## Case Analysis
+
+### Read transfer
+
+1. **Valid transaction**
+
+    Within first clock cycle (**setup phase**):
+    1. Assert `PSEL` signal
+    1. Ensure `PWRITE` signal is low
+    1. Set a valid address on `PADDR`
+    1. Ensure `PENABLE` signal is low
+    1. Ensure `PSLVERR` is not asserted
+
+    In the next clock cycle (**access phase**):
+    1. Maintain `PSELF`, `PWRITE`, and `PADDR`
+    1. Assert `PENABLE` signal
+    1. Wait until `PREADY` is asserted by the peripheral
+      a. Number of cycles in wait state should not exceed number of cycles `PREADY` is deasserted
+    1. Check that `PSLVERR` is still not asserted
+    1. Read data on `PRDATA`
+    1. Deassert `PSEL` and `PENABLE`
+
+1. **Invalid transactions**
+
+    These cases represent a modification of the above general transaction procedure.
+
+    1. `PSEL` signal deasserted before completion of transaction  
+      a. Transaction should be aborted  
+      b. Reset to pre-transaction state
+    2. `PSLVERR` is asserted before completion of transaction  
+      a. Transaction should be aborted
+      b. Reset to pre-transaction state
+    3. Invalid `PADDR`  
+      a. From the specification document: "`PADDR` indicates a byte address. `PADDR` is permitted to be unaligned with respect to the data width, but the result is UNPREDICTABLE. For example, a Completer might use the unaligned address, aligned address, or signal an error response"  
+      b. TODO: We should decide what action our completer will take. Maybe the simplest would be for `PSLVERR` to be asserted, and reset to pre-transaction state
+
+1. **Consecutive or concurrent transactions**
+
+    1. Consecutive reads
+    1. Read then write
+    1. Write then read
+    1. Consecutive reads
+    1. Consecutive reads to different devices  
+      a. We may or may not extend our test suite to cover multiple devices, but if we do, this test would entail changing which `PSEL` is asserted
+    1. Concurrent read and write  
+      a. Drive `PWDATA` while ensuring `PWRITE` signal is low  
+      b. Should result in a successful read

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,7 +34,7 @@
       b. Reset to pre-transaction state
     3. Invalid `PADDR`  
       a. From the specification document: "`PADDR` indicates a byte address. `PADDR` is permitted to be unaligned with respect to the data width, but the result is UNPREDICTABLE. For example, a Completer might use the unaligned address, aligned address, or signal an error response"  
-      b. TODO: We should decide what action our completer will take. Maybe the simplest would be for `PSLVERR` to be asserted, and reset to pre-transaction state
+      b. Our completer will be designed to require alignment. For invalid addresses, `PSLVERR` will be asserted, and the perhipheral will be reset to pre-transaction state
 
 1. **Consecutive or concurrent transactions**
 
@@ -60,7 +60,7 @@ Our testing strategy will focus on checking each protection bit with read and wr
     1. Ensure `PPROT[0]` is low
     1. Attempt a typical read transaction to an address in a privileged region
     1. Confirm that `SLVERR` is asserted
-    1. Confirm data on `PRDATA` is masked or zeroed (TODO: Maybe this it should be equal to `z`?)
+    1. Confirm data on `PRDATA` is masked by setting it equal to `z`
 
     (2) Attempt *valid read* to privileged region  
     1. Ensure `PPROT[0]` is high
@@ -88,7 +88,7 @@ Our testing strategy will focus on checking each protection bit with read and wr
     1. Ensure `PPROT[1]` is high (non-secure)
     1. Attempt a typical read transaction to an address in a secure region
     1. Confirm that `SLVERR` is asserted
-    1. Confirm data on `PRDATA` is masked or zeroed (TODO: Maybe this it should be equal to `z`?)
+    1. Confirm data on `PRDATA` is masked by setting it equal to `z`
 
     (2) Attempt *valid read* to secure region  
     1. Ensure `PPROT[1]` is low (secure)
@@ -116,7 +116,7 @@ Our testing strategy will focus on checking each protection bit with read and wr
     1. Ensure `PPROT[2]` is high (instruction access)
     1. Attempt a typical read transaction to an address in a data region
     1. Confirm that `SLVERR` is asserted
-    1. Confirm data on `PRDATA` is masked or zeroed (TODO: Maybe this it should be equal to `z`?)
+    1. Confirm data on `PRDATA` is masked by setting it equal to `z`
 
     (2) Attempt *valid read* to data region  
     1. Ensure `PPROT[2]` is low (data access)
@@ -142,7 +142,7 @@ Our testing strategy will focus on checking each protection bit with read and wr
     1. Ensure `PPROT[2]` is low (data access)
     1. Attempt a typical read transaction to an address in an instruction region
     1. Confirm that `SLVERR` is asserted
-    1. Confirm data on `PRDATA` is masked or zeroed (TODO: Maybe this it should be equal to `z`?)
+    1. Confirm data on `PRDATA` is masked by setting it equal to `z`
 
     (6) Attempt *valid read* to instruction region  
     1. Ensure `PPROT[2]` is high (instruction access)


### PR DESCRIPTION
Provides a general test plan and case analysis for read transfers and protection unit support.

This will probably be easiest to review as rendered markdown instead of the raw text. You can view the markdown by clicking on the "Display the rich diff" button indicated in the screenshot below:
![Screenshot 2025-03-01 at 11 36 12 AM](https://github.com/user-attachments/assets/9fb904f0-878a-4590-aa33-34059867c2db)
