### PR TITLE
Add initial Protection Unit tests

### DIFF
--- a/src/apb_pkg.sv
+++ b/src/apb_pkg.sv
@@ -1,18 +1,18 @@
 /*
     apb_pkg - Package for APB Interface
-    
+
     ECE 571 - Team 6 Winter 2025
 */
 
 package apb_pkg;
 
 // Possible states in APB protocol
-typedef enum {IDLE = 0, SETUP = 1, ACCESS = 2} state; 
+typedef enum {IDLE = 0, SETUP = 1, ACCESS = 2} state;
 
 // Bus Widths
-parameter ADDR_WIDTH = 16;              // Default: up to 32 bits - byte aligned 
+parameter ADDR_WIDTH = 16;              // Default: up to 32 bits - byte aligned
 parameter DATA_WIDTH = 32;              // Defaults: 8, 16, 32 bits
-parameter STRB_WIDTH = DATA_WIDTH / 8;  // PSTRB[n] corresponds to PWDATA[(8n+7):(8n)] 
+parameter STRB_WIDTH = DATA_WIDTH / 8;  // PSTRB[n] corresponds to PWDATA[(8n+7):(8n)]
 
 // Useful Parameters
 parameter TRUE = 1;
@@ -29,6 +29,21 @@ function automatic validAlign(
     logic [ALIGNBITS-1:0] compareVal = '0;
     return (baseAddr[ALIGNBITS-1:0] === compareVal) ? TRUE : FALSE;
 endfunction: validAlign
+
+// getPprot and getAddrforPprot serve as mapping functions that provide a very basic
+// memory map for the different pprot regions. We'll begin with a single region based
+// on the MSB, which represents a privileged, non-secure, instruction region of memory.
+// This may be extended in the future to accommodate more complex mappings and tests.
+// Returns correct pprot bits for the specified address
+function automatic getPprot(input [ADDR_WIDTH-1:0] addr);
+    return addr[ADDR_WIDTH - 1] ? 3'b111 : 3'd0;
+endfunction: getPprot
+
+// Returns a modified version of the recieved address to map to the specified pprot bits
+function automatic getAddrforPprot(input [2:0] pprot, input [ADDR_WIDTH-1:0] addr);
+    logic [ADDR_WIDTH-1:0] pprot_addr = addr | (1'b1 << (ADDR_WIDTH-1));
+    return pprot == 3'b111 ? pprot_addr : addr;
+endfunction: getAddrforPprot
 
 
 endpackage


### PR DESCRIPTION
Adds supporting functions and basic tests for the `pprot` bits. We'll want to expand this to the write tests as well once we have a task for those.

It would be ideal if we eventually set up a more complex memory map so we could have tests that isolate each bit (right now the only way to test the "success" case is for all the `pprot` bits to be set), but I think this is a good place to start. Definitely open to suggestions though!

Also, FYI, I tested that these files compiled, but I don't think I have a great way yet to fully test the functionality.