### PR TITLE
Fixup testbench signals and apb_pkg import

### DIFF
--- a/tb/apb_bridge.sv
+++ b/tb/apb_bridge.sv
@@ -14,6 +14,8 @@ module apb_bridge (
     apb_if.bridge apb
 );
 
+  import apb_pkg::*;
+
   logic [apb.ADDR_WIDTH-1:0] test_addr = {{(apb.ADDR_WIDTH - 4) {1'b0}}, 4'h4};
   logic [apb.DATA_WIDTH-1:0] read_data;
   logic [2:0] pprot;
@@ -91,6 +93,7 @@ module apb_bridge (
       //
       @(posedge apb.pclk);
       apb.psel    = 1;
+      apb.pprot   = pprot;
       apb.pwrite  = 0;
       // Ensure 4-byte alignment
       apb.paddr   = addr & ~(32'h3);
@@ -140,6 +143,7 @@ module apb_bridge (
       $display("Starting Invalid Read Test: Early PSEL deassertion...");
       @(posedge apb.pclk);
       apb.psel    = 1;
+      apb.pprot   = '0;
       apb.pwrite  = 0;
       apb.paddr   = 32'h4;
       apb.penable = 0;
@@ -198,6 +202,7 @@ module apb_bridge (
     // Ensure all signals start with known values
     apb.psel    = 0;
     apb.penable = 0;
+    apb.pprot   = '0;
     apb.pwrite  = 0;
     apb.paddr   = 0;
     apb.pwdata  = 0;

--- a/tb/apb_tb_top.sv
+++ b/tb/apb_tb_top.sv
@@ -39,11 +39,14 @@ module apb_tb_top;
 
   initial begin
     $display("Starting APB Test...");
+    // Reset with active-low signal, starting high since
+    // the peripheral is looking for a negedge on this signal
+    presetn = 1;
     pclk = 0;
-    // Reset with active-low signal
+    @(posedge pclk);
     presetn = 0;
-    repeat (2) @(posedge pclk);
-    // Release reset
+    @(posedge pclk);
+    // Reset complete
     presetn = 1;
     repeat (2) @(posedge pclk);
   end


### PR DESCRIPTION
I noticed a few small issues with the testbench code when testing with @tnl3pdx's changes in #21:
- The pprot helper functions were not imported correctly (resulted in an error when loading design for simulation)
- The `apb.pprot` signals needed to be updated within the read test and reset tasks
- The `presetn` signal reset sequence needed to be updated to provide the negative edge trigger that the design is waiting for