### PR TITLE
Add two basic assertions to the interface file

### DIFF
--- a/src/apb_if.sv
+++ b/src/apb_if.sv
@@ -42,4 +42,22 @@ interface apb_if #(
       input pclk, presetn, paddr, psel, penable, pwrite, pwdata, pstrb, pprot,
       output prdata, pready, pslverr
   );
+
+  //
+  // Assertions
+  //
+  // penable should only go high when psel is already high
+  property psel_before_penable;
+    @(posedge pclk) disable iff (!presetn) penable |-> psel;
+  endproperty
+  assert property (psel_before_penable)
+  else $error("penable asserted without psel being high");
+
+  // pready should only go high when psel and penable are both high
+  property pready_valid;
+    @(posedge pclk) disable iff (!presetn) pready |-> (psel && penable);
+  endproperty
+  assert property (pready_valid)
+  else $error("pready asserted without valid psel and penable");
+
 endinterface

--- a/tb/apb_bridge.sv
+++ b/tb/apb_bridge.sv
@@ -26,12 +26,12 @@ module apb_bridge (
   initial begin
     // Wait after reset before starting transactions
     repeat (4) @(posedge apb.pclk);
-    $display("Performing APB Read Transaction...");
 
     //
     // Read transfer tests
     //
     // Get expected pprot bits based on the test_addr value
+    $display("APB Read transfer tests...");
     pprot = getPprot(test_addr);
     // Test that a basic read from a reset state with correct pprot bits for the address
     // does not error and returns the data that was read
@@ -43,6 +43,7 @@ module apb_bridge (
     //
     // Protection unit tests
     //
+    $display("APB Protection Unit tests...");
     // Use pprot_bits_invert to check the individual pprot bits, one position at a time
     pprot_bits_invert = 3'b001;
     // Modify existing test address to ensure it is valid for the specified pprot bits
@@ -129,7 +130,7 @@ module apb_bridge (
       // Deassert signals
       apb.psel    = 0;
       apb.penable = 0;
-      
+
       $display("(%0t) APB Read completed in %0d cycles.", $time, wait_cycles);
     end
   endtask
@@ -155,6 +156,8 @@ module apb_bridge (
       //
       // **Break the protocol: Deassert PSEL early**
       //
+      // Turn off assertions in sections we know to have invalid actions
+      $assertoff (2, "apb_tb_top.apb");
       apb.psel = 0;
 
       // Wait for PREADY and check PSLVERR
@@ -166,6 +169,7 @@ module apb_bridge (
       @(posedge apb.pclk);
       apb.penable = 0;
       @(posedge apb.pclk);
+      $asserton (2, "apb_tb_top.apb");
     end
 
     // Test Case 2: Unaligned Address


### PR DESCRIPTION
Adds a couple of straightforward concurrent assertions in the interface file, and disables them where needed in the tests for invalid transactions.

Closes #12 